### PR TITLE
Change check for system user

### DIFF
--- a/New-AovpnDeviceConnection.ps1
+++ b/New-AovpnDeviceConnection.ps1
@@ -44,9 +44,8 @@ Param(
 
 # Script must be running in the context of the SYSTEM account to extract ProfileXML from a device tunnel connection. Validate user, exit if not running as SYSTEM.
 $CurrentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-$CurrentUserName = $CurrentPrincipal.Identities.Name
 
-If ($CurrentUserName -ne 'NT AUTHORITY\SYSTEM') {
+If ($CurrentPrincipal.Identities.IsSystem -ne $true) {
 
     Write-Warning 'This script is not running in the SYSTEM context, as required.'
     Write-Warning 'Use the Sysinternals tool Psexec.exe with the -i and -s parameters to run this script in the context of the local SYSTEM account.'


### PR DESCRIPTION
The check for NT AUTHORITY\SYSTEM only works in English versions of Windows (it's a localized string, so it's different on every localized version of Windows).
I've changed it to check for the IsSystem property, which is a Boolean (see: https://docs.microsoft.com/en-us/dotnet/api/system.security.principal.windowsidentity.issystem?view=netframework-4.8#System_Security_Principal_WindowsIdentity_IsSystem)